### PR TITLE
fix!: mark all messages properties as optional

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -165,7 +165,7 @@ func generate(req *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, 
 					Type:       typeName,
 					IsEnum:     field.GetType() == descriptor.FieldDescriptorProto_TYPE_ENUM,
 					IsRepeated: isRepeated(field),
-					IsOptional: isOptional(field),
+					IsOptional: isOptional(message, field),
 				})
 			}
 
@@ -249,8 +249,8 @@ func isRepeated(field *descriptor.FieldDescriptorProto) bool {
 	return field.Label != nil && *field.Label == descriptor.FieldDescriptorProto_LABEL_REPEATED
 }
 
-func isOptional(field *descriptor.FieldDescriptorProto) bool {
-	return field.GetType() == descriptor.FieldDescriptorProto_TYPE_MESSAGE
+func isOptional(parentMessage *descriptor.DescriptorProto, field *descriptor.FieldDescriptorProto) bool {
+	return field.GetType() == descriptor.FieldDescriptorProto_TYPE_MESSAGE && !(strings.HasSuffix(parentMessage.GetName(), "Request") || strings.HasSuffix(parentMessage.GetName(), "Response"))
 }
 
 func upperCaseFirst(s string) string {

--- a/generator.go
+++ b/generator.go
@@ -38,7 +38,7 @@ func (f *packageFile) protoFile() *protoFile {
 }
 
 var (
-    packageFiles = map[string]*packageFile{}
+	packageFiles = map[string]*packageFile{}
 )
 
 func addProtoToPackage(fileName string, pf *protoFile) {
@@ -165,6 +165,7 @@ func generate(req *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, 
 					Type:       typeName,
 					IsEnum:     field.GetType() == descriptor.FieldDescriptorProto_TYPE_ENUM,
 					IsRepeated: isRepeated(field),
+					IsOptional: isOptional(field),
 				})
 			}
 
@@ -246,6 +247,10 @@ func generate(req *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, 
 
 func isRepeated(field *descriptor.FieldDescriptorProto) bool {
 	return field.Label != nil && *field.Label == descriptor.FieldDescriptorProto_LABEL_REPEATED
+}
+
+func isOptional(field *descriptor.FieldDescriptorProto) bool {
+	return field.GetType() == descriptor.FieldDescriptorProto_TYPE_MESSAGE
 }
 
 func upperCaseFirst(s string) string {
@@ -335,6 +340,9 @@ func fieldType(f *fieldValues) string {
 	}
 	if f.IsRepeated {
 		return t + "[]"
+	}
+	if f.IsOptional {
+		t = fmt.Sprintf("%s | null", t)
 	}
 	return t
 }

--- a/template.go
+++ b/template.go
@@ -60,7 +60,7 @@ var messageTemplate = `
 export interface {{.Interface}} {
   {{- if .Fields }}
   {{- range .Fields}}
-  {{.Field }}?: {{. | fieldType}}
+  {{.Field }}: {{. | fieldType}}
   {{- end}}
   {{end}}
 }
@@ -84,6 +84,7 @@ type fieldValues struct {
 	Type       string
 	IsEnum     bool
 	IsRepeated bool
+	IsOptional bool
 }
 
 type serviceValues struct {

--- a/template.go
+++ b/template.go
@@ -60,7 +60,7 @@ var messageTemplate = `
 export interface {{.Interface}} {
   {{- if .Fields }}
   {{- range .Fields}}
-  {{.Field }}: {{. | fieldType}}
+  {{.Field }}?: {{. | fieldType}}
   {{- end}}
   {{end}}
 }


### PR DESCRIPTION
This fixes the generation of the proto `message` into TypeScript.

Currently, all fields are "required" in generated TypeScript declarations, so authors are free to access deeply nested fields without a type error, but protobuf does not provide such a guarantee.

Since proto v3 all non-scalar fields are optional by default and this cannot be changed, scalar fields are by default "required" 
 and can be marked as optional since proto v3.15.

This change is currently a draft, the following issues must be solved before the merge:

- [ ] test this with H2O AI Cloud and resolve all issues caused by unsafe property access - how to test the package locally?
- [ ] this will be a breaking change, we must release this as such - is there a versioning system in go that will guard all other consumers of this repo against grabbing the latest version?
- [ ] this currently just changes all fields to optional, which will improve TypeScript project safety, but ideally, we shall change only non-scalar types to optional and check an `optional` flag for scalar types to prevent excessive null value checks in TypeScript projects