### PR TITLE
feat: ✨ Basic support for nested types

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -37,7 +37,9 @@ func (f *packageFile) protoFile() *protoFile {
 	return pf
 }
 
-var packageFiles = map[string]*packageFile{}
+var (
+    packageFiles = map[string]*packageFile{}
+)
 
 func addProtoToPackage(fileName string, pf *protoFile) {
 	if _, ok := packageFiles[fileName]; !ok {
@@ -47,7 +49,10 @@ func addProtoToPackage(fileName string, pf *protoFile) {
 }
 
 func samePackage(a *descriptor.FileDescriptorProto, b *descriptor.FileDescriptorProto) bool {
-	return a.GetPackage() == b.GetPackage()
+	if a.GetPackage() != b.GetPackage() {
+		return false
+	}
+	return true
 }
 
 func fullTypeName(fd *descriptor.FileDescriptorProto, typeName string) string {
@@ -339,7 +344,7 @@ func singularFieldType(m *descriptor.DescriptorProto, f *descriptor.FieldDescrip
 		return f.GetTypeName()
 
 	default:
-		// log.Printf("unknown type %q in field %q", f.GetType(), f.GetName())
+		//log.Printf("unknown type %q in field %q", f.GetType(), f.GetName())
 		return "string"
 	}
 }

--- a/main.go
+++ b/main.go
@@ -1,12 +1,11 @@
 package main
 
 import (
-	"log"
-	"os"
-
 	"errors"
 	"io"
 	"io/ioutil"
+	"log"
+	"os"
 
 	"github.com/golang/protobuf/proto"
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"

--- a/main.go
+++ b/main.go
@@ -1,11 +1,12 @@
 package main
 
 import (
+	"log"
+	"os"
+
 	"errors"
 	"io"
 	"io/ioutil"
-	"log"
-	"os"
 
 	"github.com/golang/protobuf/proto"
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"

--- a/template.go
+++ b/template.go
@@ -69,9 +69,14 @@ export interface {{.Interface}} {
 {{range .NestedEnums}}
 {{. | compile}}
 {{end}}
-{{else}}
-
 {{ end -}}
+
+{{- if .NestedTypes}}
+{{range .NestedTypes}}
+{{. | compile}}
+{{end}}
+{{ end -}}
+
 `
 
 func (mv *messageValues) Compile() (string, error) {


### PR DESCRIPTION
This unblocks where https://github.com/h2oai/h2o-ai-cloud/issues/2453 the the message that now requires generated code contains map field.

Maps are nested types.

```proto
message Message_PascalCaseFieldNameEntry {
	KeyType key = 1;
    ValueType value = 2;
```

This is really simple solution with no attempt to solve the recursion as that would mean refactor the code beyond the extraction of one function.